### PR TITLE
Skip grub updates for all hosts

### DIFF
--- a/build-control.sh
+++ b/build-control.sh
@@ -2,6 +2,7 @@
 
 # Update and install packages
 apt-mark hold cloud-init
+apt-mark hold grub*
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 apt-get -y install bridge-utils zfsutils-linux

--- a/build-hosts.sh
+++ b/build-hosts.sh
@@ -2,6 +2,7 @@
 
 # Update and install packages
 apt-mark hold cloud-init
+apt-mark hold grub*
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get -y upgrade
 


### PR DESCRIPTION
This copies the `apt-mark hold grub*` command from `build-edge.sh` into `build-control.sh` and `build-hosts.sh` in order to prevent grub from updating on all machines.  Grub updates were reliably breaking cloud-init issues on `m3.small.x86` instances and intermittently breaking cloud-init on `m3.large.x86` instances, which broke deployment at the Juju bootstrap stage.